### PR TITLE
Version `0.3.0-1.4-rc`: Some data classes are now serializable.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,14 @@ import org.gradle.internal.impldep.org.apache.http.impl.auth.BasicScheme
 
 plugins {
     kotlin("multiplatform") version "1.4.0-rc"
+    kotlin("plugin.serialization") version "1.4.0-rc"
     `maven-publish`
 }
 
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoink"
-version = "0.2.0-1.4-rc"
+version = "0.3.0-1.4-rc"
 
 repositories {
     mavenLocal()
@@ -43,6 +44,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:1.0-M1-1.4.0-rc")
                 api("fr.acinq.secp256k1:secp256k1:$secp256k1KmpVersion")
             }
         }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Block.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Block.kt
@@ -43,11 +43,9 @@ public data class BlockHeader(
     @JvmField val bits: Long,
     @JvmField val nonce: Long
 ) {
-    @JvmField
-    public val hash: ByteVector32 = ByteVector32(Crypto.hash256(write(this)))
+    public val hash: ByteVector32 get() = ByteVector32(Crypto.hash256(write(this)))
 
-    @JvmField
-    public val blockId: ByteVector32 = hash.reversed()
+    public val blockId: ByteVector32 get() = hash.reversed()
 
     public fun setVersion(input: Long): BlockHeader = this.copy(version = input)
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Block.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Block.kt
@@ -20,6 +20,7 @@ import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -43,9 +44,11 @@ public data class BlockHeader(
     @JvmField val bits: Long,
     @JvmField val nonce: Long
 ) {
-    public val hash: ByteVector32 get() = ByteVector32(Crypto.hash256(write(this)))
+    @JvmField @Transient
+    public val hash: ByteVector32 = ByteVector32(Crypto.hash256(write(this)))
 
-    public val blockId: ByteVector32 get() = hash.reversed()
+    @JvmField @Transient
+    public val blockId: ByteVector32 = hash.reversed()
 
     public fun setVersion(input: Long): BlockHeader = this.copy(version = input)
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Block.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Block.kt
@@ -19,6 +19,7 @@ package fr.acinq.bitcoin
 import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.secp256k1.Hex
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -33,6 +34,7 @@ import kotlin.jvm.JvmStatic
  * @param nonce             The nonce used to generate this block… to allow variations of the header and compute different hashes
  */
 @OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
 public data class BlockHeader(
     @JvmField val version: Long,
     @JvmField val hashPreviousBlock: ByteVector32,

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/ByteVector.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/ByteVector.kt
@@ -19,14 +19,9 @@ package fr.acinq.bitcoin
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.builtins.ArraySerializer
-import kotlinx.serialization.builtins.ByteArraySerializer
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.experimental.or
@@ -39,9 +34,9 @@ public open class ByteVector(internal val bytes: ByteArray, internal val offset:
     public constructor(input: String) : this(Hex.decode(input))
 
     init {
-        require(offset >= 0){ "offset must be > 0"}
-        require(size >= 0){"size must be > 0"}
-        require(offset + size <= bytes.size){"offset + size must be <= buffer size"}
+        require(offset >= 0){ "offset ($size) must be > 0"}
+        require(size >= 0){"size ($size) must be > 0"}
+        require(offset + size <= bytes.size){"offset ($offset) + size ($size) must be <= buffer size (${bytes.size})"}
     }
 
     public fun size(): Int = size
@@ -205,11 +200,6 @@ public class ByteVector32(bytes: ByteArray, offset: Int) : ByteVector(bytes, off
 public class ByteVector64(bytes: ByteArray, offset: Int) : ByteVector(bytes, offset, 64) {
     public constructor(bytes: ByteArray) : this(bytes, 0)
     public constructor(input: String) : this(Hex.decode(input), 0)
-
-    init {
-        require(offset >= 0 && offset < bytes.size)
-        require(bytes.size - offset == 64) { "ByteVector64 must contain 64 bytes, not ${bytes.size - offset}" }
-    }
 
     public companion object {
         @JvmField

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/ByteVector.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/ByteVector.kt
@@ -17,10 +17,23 @@
 package fr.acinq.bitcoin
 
 import fr.acinq.secp256k1.Hex
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.builtins.ArraySerializer
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlin.experimental.or
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
+@Serializable(with = ByteVector.Serializer::class)
 public open class ByteVector(internal val bytes: ByteArray, internal val offset: Int, private val size: Int) {
     public constructor(bytes: ByteArray) : this(bytes, 0, bytes.size)
     public constructor(input: String) : this(Hex.decode(input))
@@ -136,9 +149,21 @@ public open class ByteVector(internal val bytes: ByteArray, internal val offset:
         @JvmField
         public val empty: ByteVector = ByteVector(ByteArray(0))
     }
+
+    public object Serializer: KSerializer<ByteVector> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ByteVector", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ByteVector) {
+            encoder.encodeString(value.toHex())
+        }
+
+        override fun deserialize(decoder: Decoder): ByteVector {
+            return ByteVector(decoder.decodeString())
+        }
+    }
 }
 
-
+@Serializable(with = ByteVector32.Serializer::class)
 public class ByteVector32(bytes: ByteArray, offset: Int) : ByteVector(bytes, offset, 32) {
     public constructor(bytes: ByteArray) : this(bytes, 0)
     public constructor(input: String) : this(Hex.decode(input), 0)
@@ -162,8 +187,21 @@ public class ByteVector32(bytes: ByteArray, offset: Int) : ByteVector(bytes, off
         @JvmStatic
         public fun fromValidHex(input: String): ByteVector32 = ByteVector32(input)
     }
+
+    public object Serializer: KSerializer<ByteVector32> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ByteVector32", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ByteVector32) {
+            encoder.encodeString(value.toHex())
+        }
+
+        override fun deserialize(decoder: Decoder): ByteVector32 {
+            return ByteVector32(decoder.decodeString())
+        }
+    }
 }
 
+@Serializable(with = ByteVector64.Serializer::class)
 public class ByteVector64(bytes: ByteArray, offset: Int) : ByteVector(bytes, offset, 64) {
     public constructor(bytes: ByteArray) : this(bytes, 0)
     public constructor(input: String) : this(Hex.decode(input), 0)
@@ -179,6 +217,18 @@ public class ByteVector64(bytes: ByteArray, offset: Int) : ByteVector(bytes, off
 
         @JvmStatic
         public fun fromValidHex(input: String): ByteVector64 = ByteVector64(input)
+    }
+
+    public object Serializer: KSerializer<ByteVector64> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ByteVector64", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ByteVector64) {
+            encoder.encodeString(value.toHex())
+        }
+
+        override fun deserialize(decoder: Decoder): ByteVector64 {
+            return ByteVector64(decoder.decodeString())
+        }
     }
 }
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
@@ -45,11 +45,9 @@ public object DeterministicWallet {
         @JvmField val path: KeyPath,
         @JvmField val parent: Long
     ) {
-        @JvmField
-        val privateKey: PrivateKey = PrivateKey(secretkeybytes)
+        val privateKey: PrivateKey get() = PrivateKey(secretkeybytes)
 
-        @JvmField
-        val publicKey: PublicKey = privateKey.publicKey()
+        val publicKey: PublicKey get() = privateKey.publicKey()
     }
 
     @Serializable
@@ -64,8 +62,7 @@ public object DeterministicWallet {
             require(publickeybytes.size() == 33)
         }
 
-        @JvmField
-        val publicKey: PublicKey = PublicKey(publickeybytes)
+        val publicKey: PublicKey get() = PublicKey(publickeybytes)
     }
 
     @JvmStatic
@@ -276,8 +273,7 @@ public object DeterministicWallet {
 public data class KeyPath(@JvmField val path: List<Long>) {
     public constructor(path: String) : this(computePath(path))
 
-    @JvmField
-    public val lastChildNumber: Long = if (path.isEmpty()) 0L else path.last()
+    public val lastChildNumber: Long get() = if (path.isEmpty()) 0L else path.last()
 
     public fun derive(number: Long): KeyPath = KeyPath(path + listOf(number))
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
@@ -20,6 +20,7 @@ import fr.acinq.bitcoin.DeterministicWallet.hardened
 import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.bitcoin.io.ByteArrayInput
 import fr.acinq.bitcoin.io.ByteArrayOutput
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -36,6 +37,7 @@ public object DeterministicWallet {
     @JvmStatic
     public fun isHardened(index: Long): Boolean = index >= hardenedKeyIndex
 
+    @Serializable
     public data class ExtendedPrivateKey(
         @JvmField val secretkeybytes: ByteVector32,
         @JvmField val chaincode: ByteVector32,
@@ -50,6 +52,7 @@ public object DeterministicWallet {
         val publicKey: PublicKey = privateKey.publicKey()
     }
 
+    @Serializable
     public data class ExtendedPublicKey(
         @JvmField val publickeybytes: ByteVector,
         @JvmField val chaincode: ByteVector32,
@@ -269,6 +272,7 @@ public object DeterministicWallet {
     public const val vpub: Int = 0x045f1cf6
 }
 
+@Serializable
 public data class KeyPath(@JvmField val path: List<Long>) {
     public constructor(path: String) : this(computePath(path))
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
@@ -21,6 +21,7 @@ import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.bitcoin.io.ByteArrayInput
 import fr.acinq.bitcoin.io.ByteArrayOutput
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -45,9 +46,11 @@ public object DeterministicWallet {
         @JvmField val path: KeyPath,
         @JvmField val parent: Long
     ) {
-        val privateKey: PrivateKey get() = PrivateKey(secretkeybytes)
+        @JvmField @Transient
+        val privateKey: PrivateKey = PrivateKey(secretkeybytes)
 
-        val publicKey: PublicKey get() = privateKey.publicKey()
+        @JvmField @Transient
+        val publicKey: PublicKey = privateKey.publicKey()
     }
 
     @Serializable

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/PrivateKey.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/PrivateKey.kt
@@ -18,9 +18,11 @@ package fr.acinq.bitcoin
 
 import fr.acinq.secp256k1.Hex
 import fr.acinq.secp256k1.Secp256k1
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
+@Serializable
 public data class PrivateKey(@JvmField val value: ByteVector32) {
     public constructor(data: ByteArray) : this(
         when {

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/PublicKey.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/PublicKey.kt
@@ -18,9 +18,11 @@ package fr.acinq.bitcoin
 
 import fr.acinq.secp256k1.Hex
 import fr.acinq.secp256k1.Secp256k1
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
+@Serializable
 public data class PublicKey(@JvmField val value: ByteVector) {
     public constructor(data: ByteArray) : this(ByteVector(data))
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Satoshi.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Satoshi.kt
@@ -1,5 +1,8 @@
 package fr.acinq.bitcoin
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 public data class Satoshi(val sat: Long) : Comparable<Satoshi> {
     // @formatter:off
     public operator fun plus(other: Satoshi): Satoshi = Satoshi(sat + other.sat)

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -21,6 +21,7 @@ import fr.acinq.bitcoin.io.ByteArrayOutput
 import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.secp256k1.Hex
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -31,6 +32,7 @@ import kotlin.jvm.JvmStatic
  * @param index index of the output in tx that we want to refer to
  */
 @OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
 public data class OutPoint(@JvmField val hash: ByteVector32, @JvmField val index: Long) : BtcSerializable<OutPoint> {
     public constructor(hash: ByteArray, index: Long) : this(hash.byteVector32(), index)
 
@@ -77,6 +79,7 @@ public data class OutPoint(@JvmField val hash: ByteVector32, @JvmField val index
     override fun serializer(): BtcSerializer<OutPoint> = OutPoint
 }
 
+@Serializable
 public data class ScriptWitness(@JvmField val stack: List<ByteVector>) : BtcSerializable<ScriptWitness> {
     public constructor() : this(listOf())
 
@@ -125,6 +128,7 @@ public data class ScriptWitness(@JvmField val stack: List<ByteVector>) : BtcSeri
  * @param witness         Transaction witness (i.e. what is in sig script for standard transactions).
  */
 @OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
 public data class TxIn(
     @JvmField val outPoint: OutPoint,
     @JvmField val signatureScript: ByteVector,
@@ -213,6 +217,7 @@ public data class TxIn(
 }
 
 @OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
 public data class TxOut(@JvmField val amount: Satoshi, @JvmField val publicKeyScript: ByteVector) : BtcSerializable<TxOut> {
 
     public constructor(amount: Satoshi, publicKeyScript: ByteArray) : this(amount, publicKeyScript.byteVector())
@@ -261,6 +266,7 @@ public data class TxOut(@JvmField val amount: Satoshi, @JvmField val publicKeySc
 }
 
 @OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
 public data class Transaction(
     @JvmField val version: Long,
     @JvmField val txIn: List<TxIn>,

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -22,6 +22,7 @@ import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -46,7 +47,8 @@ public data class OutPoint(@JvmField val hash: ByteVector32, @JvmField val index
      *
      * @return the id of the transaction this output belongs to
      */
-    public val txid: ByteVector32 get() = hash.reversed()
+    @JvmField @Transient
+    public val txid: ByteVector32 = hash.reversed()
 
     public val isCoinbase: Boolean get() = isCoinbase(this)
 
@@ -273,7 +275,8 @@ public data class Transaction(
 
     public val hasWitness: Boolean get() = txIn.any { it.hasWitness }
 
-    public val hash: ByteVector32 get() = ByteVector32(
+    @JvmField @Transient
+    public val hash: ByteVector32 = ByteVector32(
         Crypto.hash256(
             Transaction.write(
                 this,
@@ -282,7 +285,8 @@ public data class Transaction(
         )
     )
 
-    public val txid: ByteVector32 get() = hash.reversed()
+    @JvmField @Transient
+    public val txid: ByteVector32 = hash.reversed()
 
     /**
      *

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -46,11 +46,9 @@ public data class OutPoint(@JvmField val hash: ByteVector32, @JvmField val index
      *
      * @return the id of the transaction this output belongs to
      */
-    @JvmField
-    public val txid: ByteVector32 = hash.reversed()
+    public val txid: ByteVector32 get() = hash.reversed()
 
-    @JvmField
-    public val isCoinbase: Boolean = isCoinbase(this)
+    public val isCoinbase: Boolean get() = isCoinbase(this)
 
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     public companion object : BtcSerializer<OutPoint>() {
@@ -150,11 +148,9 @@ public data class TxIn(
         sequence
     )
 
-    @JvmField
-    public val isFinal: Boolean = sequence == SEQUENCE_FINAL
+    public val isFinal: Boolean get() = sequence == SEQUENCE_FINAL
 
-    @JvmField
-    public val hasWitness: Boolean = witness.isNotNull()
+    public val hasWitness: Boolean get() = witness.isNotNull()
 
     public fun updateSignatureScript(signatureScript: ByteVector): TxIn = this.copy(signatureScript = signatureScript)
 
@@ -275,11 +271,9 @@ public data class Transaction(
 ) :
     BtcSerializable<Transaction> {
 
-    @JvmField
-    public val hasWitness: Boolean = txIn.any { it.hasWitness }
+    public val hasWitness: Boolean get() = txIn.any { it.hasWitness }
 
-    @JvmField
-    public val hash: ByteVector32 = ByteVector32(
+    public val hash: ByteVector32 get() = ByteVector32(
         Crypto.hash256(
             Transaction.write(
                 this,
@@ -288,8 +282,7 @@ public data class Transaction(
         )
     )
 
-    @JvmField
-    public val txid: ByteVector32 = hash.reversed()
+    public val txid: ByteVector32 get() = hash.reversed()
 
     /**
      *

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/ByteVectorTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/ByteVectorTestsCommon.kt
@@ -1,0 +1,49 @@
+package fr.acinq.bitcoin
+
+import fr.acinq.secp256k1.Hex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ByteVectorTestsCommon {
+
+    @Test fun `equality between different byte vectors`() {
+        assertEquals(
+            ByteVector32("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"),
+            ByteVector(Hex.decode("FFFF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0000"), 2, 32)
+        )
+
+        assertEquals(
+            ByteVector("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"),
+            ByteVector32(Hex.decode("FFFF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0000"), 2)
+        )
+
+        assertEquals(
+            ByteVector64("FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210"),
+            ByteVector(Hex.decode("0000FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FFFF"), 2, 64)
+        )
+
+        assertEquals(
+            ByteVector("FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210"),
+            ByteVector64(Hex.decode("0000FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FFFF"), 2)
+        )
+    }
+
+    @Test fun `bad sized vectors`() {
+        assertFailsWith<IllegalArgumentException> { ByteVector32("0123456789ABCDEF") }.let {
+            assertEquals("offset (0) + size (32) must be <= buffer size (8)", it.message)
+        }
+
+        assertFailsWith<IllegalArgumentException> { ByteVector32(Hex.decode("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"), 8) }.let {
+            assertEquals("offset (8) + size (32) must be <= buffer size (32)", it.message)
+        }
+
+        assertFailsWith<IllegalArgumentException> { ByteVector64("0123456789ABCDEF0123456789ABCDEF") }.let {
+            assertEquals("offset (0) + size (64) must be <= buffer size (16)", it.message)
+        }
+
+        assertFailsWith<IllegalArgumentException> { ByteVector64(Hex.decode("FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210"), 16) }.let {
+            assertEquals("offset (16) + size (64) must be <= buffer size (64)", it.message)
+        }
+    }
+}


### PR DESCRIPTION
This PR makes certain classes Serializable with KotlinX.Serialization: `BlockHeader` , `ByteVector`, `ByteVector32`, `ByteVector64`, `DeterministicWallet.ExtendedPrivateKey`, `DeterministicWallet.ExtendedPublicKey`, `KeyPath`, `PrivateKey`, `PublicKey`, `Satoshi`, `OutPoint`, `ScriptWitness`, `TxIn`, `TxOut`, `Transaction`.

Because a serializable class must not have property fields outside of its constructor unless marked `@Transient`, fast-computed properties where transformed as getters functions while slow computed properties where marked `@Transient`. 

Note: `ByteVectorX` classes are actually serialized into hexadecimal `String`, because:
- This allows for easier inspection (when using CBOR with tools like [cbor.me](https://cbor.me)).
- When using JSON, this actually saves a lot of space (as opposed to base 10 numbers separated by comas). If we assume homogenous value distribution (-128 to +127), a 32 byte array would take around 118 characters as a JSON array, and exactly 66 characters as a JSON hex string.
- When using CBOR, this actually consumes very little more space because KotlinX CBOR only uses generic arrays, and not binary strings. If we assume homogenous value distribution (-128 to +127), a 32 byte array would take around 60 bytes as a CBOR array (it would take exactly 34 bytes as a CBOR binary String), and exactly 66 bytes as a CBOR hex string (see [RFC](https://tools.ietf.org/html/rfc7049#section-2.2.1)).

Note: Using Base64 would allow even greater space optimization, as it would take exactly 46 bytes both as a JSON or CBOR string, but using hexadecimal makes it easier to interop with existing tools as well as with human eyes ;)